### PR TITLE
Add group-by-label feature

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 
 interface Group {
   name: string
+  matchLabel?: string
   reviewers?: number
   internal_reviewers?: number
   usernames: string[]


### PR DESCRIPTION
The idea of this feature is to limit which groups get selected for review on a given PR. It adds a match tag to groups with the effect that if the PR has labels, only groups whose matcher is present in one of these labels get selected for reviews.

The use case for this is multiplatform or multiteam monorepos to not get all the groups in an organization reviewing every single PR.